### PR TITLE
Quick Fix - Errori di Compilazione Latex

### DIFF
--- a/src/documenti/esterni/AdR/contenuti/casi_uso.tex
+++ b/src/documenti/esterni/AdR/contenuti/casi_uso.tex
@@ -47,7 +47,6 @@
       \item Fallisce il caricamento della sessione precedente;
       \item Viene visualizzato un errore esplicativo [UC4].
     \end{enumerate}
-  \end{enumerate}
 \end{itemize}
 \subsection{UC3 - Visualizzazione errore inserimento dati}
 \begin{itemize}
@@ -70,6 +69,7 @@
     \item L'utente visualizza un messaggio di errore esplicativo;
     \item L'utente clicca \texttt{Capito} per tornare alla schermata iniziale.
   \end{enumerate}
+\end{itemize}
 
 \section{UC3 - Selezione dimensioni}
  \begin{itemize}


### PR DESCRIPTION
Erano presenti 2 minuscoli errori di sintassi che tuttavia non permettevano di compilare i file latex in PDF