### PR TITLE
NdP - Fix vari

### DIFF
--- a/src/documenti/interni/NdP/contenuti/modifiche.tex
+++ b/src/documenti/interni/NdP/contenuti/modifiche.tex
@@ -8,6 +8,7 @@
   \begin{tabular}{|p{2cm}|p{2cm}|p{4cm}|p{5cm}|}
     \hline
     \textbf{Versione} & \textbf{Data} & \textbf{Autore/Verificatore} & \textbf{Modifica}                    \\ \hline
+    v0.1.4            & 02/02/2022    & \aCapo{Marko Vukovic\\} & Aggiunta sezione Glossario. Fix: processi primari, supporto. Fix minori   \\ \hline           
     v0.1.3            & 09/01/2022    & \aCapo{Marco Mamprin\\Emanuele Pase} & Aggiunte sottosezione "Metriche"  \\ \hline           
     v0.1.2            & 07/01/2022    & \aCapo{Riccardo Contin\\Marko Vukovic} & Aggiunte sottosezioni "Preventivo" e "Consuntivo"  \\ \hline
     v0.1.1            & 02/01/2022    & \aCapo{Marko Vukovic\\Emanuele Pase} & Aggiunta sezione automazione  \\ \hline

--- a/src/documenti/interni/NdP/contenuti/modifiche.tex
+++ b/src/documenti/interni/NdP/contenuti/modifiche.tex
@@ -8,7 +8,7 @@
   \begin{tabular}{|p{2cm}|p{2cm}|p{4cm}|p{5cm}|}
     \hline
     \textbf{Versione} & \textbf{Data} & \textbf{Autore/Verificatore} & \textbf{Modifica}                    \\ \hline
-    v0.1.4            & 02/02/2022    & \aCapo{Marko Vukovic\\} & Aggiunta sezione Glossario. Fix: processi primari, supporto. Fix minori   \\ \hline           
+    v0.1.4            & 02/02/2022    & \aCapo{Marko Vukovic\\Marco Mamprin} & Aggiunta sezione Glossario. Fix: processi primari, supporto. Fix minori   \\ \hline           
     v0.1.3            & 09/01/2022    & \aCapo{Marco Mamprin\\Emanuele Pase} & Aggiunte sottosezione "Metriche"  \\ \hline           
     v0.1.2            & 07/01/2022    & \aCapo{Riccardo Contin\\Marko Vukovic} & Aggiunte sottosezioni "Preventivo" e "Consuntivo"  \\ \hline
     v0.1.1            & 02/01/2022    & \aCapo{Marko Vukovic\\Emanuele Pase} & Aggiunta sezione automazione  \\ \hline

--- a/src/documenti/interni/NdP/contenuti/processi_organizzativi.tex
+++ b/src/documenti/interni/NdP/contenuti/processi_organizzativi.tex
@@ -144,16 +144,16 @@ La \textbf{board principale} è divisa nelle seguenti liste:
 
 Ciascuna \textbf{task} è costituita da:
 \begin{itemize}
-  \item \textbf{titolo} sintetico nella seguente forma generale: \textit{[categoria] - [breve titolo significativo]} (e.g. \texttt{documentazione - verbale meeting interno 23/11/2021});
-  \item \textbf{descrizione} opzionale e breve per dettagli importanti;
-  \item \textbf{membro/i} del gruppo coinvolti nella task;
-  \item \textbf{tag} per segnalare particolarità della task. Le etichette principali definite sono:
+  \item \textbf{Titolo} sintetico nella seguente forma generale: \textit{[categoria] - [breve titolo significativo]} (e.g. \texttt{documentazione - verbale meeting interno 23/11/2021});
+  \item \textbf{Descrizione} opzionale e breve per dettagli importanti;
+  \item \textbf{Membro/i} del gruppo coinvolti nella task;
+  \item \textbf{Tag} per segnalare particolarità della task. Le etichette principali definite sono:
   \begin{itemize}
     \item \texttt{Importante}: segnala una task con alto livello di priorità;
     \item \texttt{Team}: segnala una task che necessita del coinvolgimento dell'intero team. Rimane comunque che ci deve essere un membro incaricato Responsabile per quella determinata task;
     \item \texttt{Approved}: segnala una task in "Verify" che è stata verificata e può essere spostata (dal \textit{Responsabile di Progetto}) in "Done".
   \end{itemize}
-  \item \textbf{commenti} per discutere (soprattutto asincronamente) sulla specifica task.
+  \item \textbf{Commenti} per discutere (soprattutto asincronamente) sulla specifica task.
 \end{itemize}
 Le task inserite nel sistema non vengono \underline{mai cancellate} ma solo spostate tra le liste presenti. Solo in casi eccezionali le task possono essere archiviate ma anche in questo caso di loro e della loro storia resta traccia.
 
@@ -164,12 +164,12 @@ Per navigare più facilmente nella bacheca è possibile impostare dei \textbf{fi
 
 Generalmente il workflow adottato dal gruppo è il GitHub Flow, che sinteticamente segue il seguente schema:
 \begin{itemize}
-  \item riallineamento della repository locale con quella remota;
-  \item creazione di un branch locale su cui effettuare le modifiche;
-  \item push del branch locale verso repository remota;
-  \item creazione di una pull request;
-  \item verifica e successivo merge del branch con le modifiche;
-  \item eliminazione del branch utilizzato dalla repository remota.
+  \item Riallineamento della repository locale con quella remota;
+  \item Creazione di un branch locale su cui effettuare le modifiche;
+  \item Push del branch locale verso repository remota;
+  \item Creazione di una pull request;
+  \item Verifica e successivo merge del branch con le modifiche;
+  \item Eliminazione del branch utilizzato dalla repository remota.
 \end{itemize}
 Per i dettagli consultare la documentazione ufficiale:
 \begin{itemize}
@@ -199,23 +199,23 @@ Calendario condiviso del gruppo utilizzato per comunicare e ricordare:
 \begin{itemize}
   \item \textbf{Meeting Interni}: di cui saranno specificati:
   \begin{itemize}
-    \item orario di inizio;
-    \item moderatore;
-    \item scriba (redazione verbale);
-    \item argomenti: specifiche idee da trattare durante una riunione del gruppo.
+    \item Orario di inizio;
+    \item Moderatore;
+    \item Scriba (redazione verbale);
+    \item Argomenti: specifiche idee da trattare durante una riunione del gruppo.
   \end{itemize}
   \item \textbf{Meeting Esterni}: con proponente o committente;
   \item \textbf{Scadenze Interne};
   \item \textbf{Scadenze Esterne};
-  \item qualsiasi altra attività o evento che può essere collocato in un tempo specifico.
+  \item Qualsiasi altra attività o evento che può essere collocato in un tempo specifico.
 \end{itemize}
 Mantenere il calendario aggiornato è compito del \textit{Responsabile di Progetto}.
 
 \subsubsection{Google Drive}
 Strumento utilizzato come:
 \begin{itemize}
-  \item \textbf{directory condivisa} dai membri del gruppo per documenti temporanei o non ufficiali;
-  \item accesso alla \textbf{suite Google}: Docs, Sheets, Slides.
+  \item \textbf{Directory condivisa} dai membri del gruppo per documenti temporanei o non ufficiali;
+  \item Accesso alla \textbf{suite Google}: Docs, Sheets, Slides.
 \end{itemize}
 
 \subsubsection{Zoom}

--- a/src/documenti/interni/NdP/contenuti/processi_organizzativi.tex
+++ b/src/documenti/interni/NdP/contenuti/processi_organizzativi.tex
@@ -178,8 +178,6 @@ Per i dettagli consultare la documentazione ufficiale:
 
 GitHub offre un sistema di "Issue" e "Milestone" per pianificare e coordinare le attività da svolgere. Tipicamente sarà compito del \textit{Responsabile di progetto} predisporre le issue relative a una particolare milestone in modo che il resto del team possa avere più autonomia, potendo autoassegnarsi issue ancora aperte. Idealmente le issue saranno collegate con una o più pull request.
 
-\todo{il sistema di Issue e Milestone di GitHub deve ancora essere utilizzato e approfondito}
-
 \subsubsection{Discord}
 Principale strumento di \textbf{comunicazione interna sincrona} e \textbf{asincrona}. Vengono utilizzati 3 categorie di canali:
 \begin{itemize}

--- a/src/documenti/interni/NdP/contenuti/processi_organizzativi.tex
+++ b/src/documenti/interni/NdP/contenuti/processi_organizzativi.tex
@@ -237,5 +237,4 @@ Di seguito sono riportati gli strumenti e le tecnologie utilizzate, con i princi
     \item Git: \url{https://docs.github.com/en/get-started/using-git/about-git};
     \item GitHub: \url{https://docs.github.com};
     \item GitHub Flow: \url{https://docs.github.com/en/get-started/quickstart/github-flow}.
-    \item \todo{Tecnologie software}.
 \end{itemize}

--- a/src/documenti/interni/NdP/contenuti/processi_primari.tex
+++ b/src/documenti/interni/NdP/contenuti/processi_primari.tex
@@ -60,10 +60,18 @@ Durante l'intera realizzazione del progetto il gruppo \textit{MERL} intende mant
     \subsubsection{Struttura dei requisiti}
       Il codice identificativo di ciascun requisito è di seguito riportato:
       \begin{center}
-        \textbf{R[Importanza].[Codice]}\\
+        \textbf{R[Tipologia].[Importanza].[Codice]}\\
       \end{center}
       con:
       \begin{itemize}
+        \item Tipologia:
+        \begin{itemize}
+          \item \textbf{V}: requisito di vincolo (vincoli sui servizi offerti dal sistema);
+          \item \textbf{F}: requisito funzionale (servizi e funzioni offerti dal sistema);
+          \item \textbf{P}: requisito prestazionale (vincoli sulle prestazioni da soddisfare);
+          \item \textbf{Q}: requisito di qualità (vincoli di qualità, vedere il \textit{Piano di Qualifica} per i dettagli);
+        \end{itemize}
+
         \item Importanza:
         \begin{itemize}
           \item \textbf{1} requisito obbligatorio;

--- a/src/documenti/interni/NdP/contenuti/processi_supporto.tex
+++ b/src/documenti/interni/NdP/contenuti/processi_supporto.tex
@@ -121,9 +121,9 @@ Gli stili di testo adottati nei documenti sono:
     \item Il nome delle subsection e inferiori solo la prima lettera maiuscola.
 \end{itemize}
 \subsection{Glossario}
-Il \textit{glossario} è un documento contenente vocaboli tecnici o ambigui per cui il gruppo sente la necessità di definire una descrizione comune per poter comunicare in modo più conciso ed efficiente.
+Il \textit{Glossario} è un documento contenente vocaboli tecnici o ambigui per cui il gruppo sente la necessità di definire una descrizione comune per poter comunicare in modo più conciso ed efficiente.
 
-Il \textit{glossario} è un documento condiviso su Google Drive a cui hanno accesso in lettura e scrittura tutti i membri del gruppo. Se durante il progetto didattico si incontra qualche termine particolarmente significativo, qualsiasi membro del gruppo può inserirlo insieme alla relativa definizione all'interno del \textit{glossario}, verificando che esso non sia già presente.
+Il \textit{Glossario} è un documento condiviso su Google Drive a cui hanno accesso in lettura e scrittura tutti i membri del gruppo. Se durante il progetto didattico si incontra qualche termine particolarmente significativo, qualsiasi membro del gruppo può inserirlo insieme alla relativa definizione all'interno del \textit{Glossario}, verificando che esso non sia già presente.
 
 \subsection{Sigle}
 \label{sigle}

--- a/src/documenti/interni/NdP/contenuti/processi_supporto.tex
+++ b/src/documenti/interni/NdP/contenuti/processi_supporto.tex
@@ -81,8 +81,6 @@ Ogni documento presenta un registro delle modifiche sotto forma di tabella che t
 \end{itemize}
 \subsection{Indice}
 Ogni documento presenta un indice dei contenuti, subito dopo il registro delle modifiche. Dove necessario, sono presenti anche un indice delle illustrazioni e uno delle tabelle presenti nel documento.
-\subsection{Struttura delle pagine}
-La singola pagina del documento ha la seguente struttura: \todo{decidere insieme la struttura}
 \subsection{Verbali}
 I Verbali contengono la prima pagina come gli altri documenti ma non viene messo l'indice data la brevità di questi documenti. Il contenuto di un Verbale è così organizzato:
 \begin{itemize}
@@ -123,7 +121,10 @@ Gli stili di testo adottati nei documenti sono:
     \item Il nome delle subsection e inferiori solo la prima lettera maiuscola.
 \end{itemize}
 \subsection{Glossario}
-\todo{aspetto che prima lo facciamo e decidiamo come impostarlo}
+Il \textit{glossario} è un documento contenente vocaboli tecnici o ambigui per cui il gruppo sente la necessità di definire una descrizione comune per poter comunicare in modo più conciso ed efficiente.
+
+Il \textit{glossario} è un documento condiviso su Google Drive a cui hanno accesso in lettura e scrittura tutti i membri del gruppo. Se durante il progetto didattico si incontra qualche termine particolarmente significativo, qualsiasi membro del gruppo può inserirlo insieme alla relativa definizione all'interno del \textit{glossario}, verificando che esso non sia già presente.
+
 \subsection{Sigle}
 \label{sigle}
 \begin{itemize}
@@ -201,10 +202,10 @@ Per ogni periodo pianificato e per cui si è fatto un preventivo si vuole indica
  \subsection{Descrizione}
     Il processo di gestione della configurazione ha lo scopo di creare un ambiente in cui la produzione di
     documentazione e di codice avviene in maniera sistematica, ordinata e standardizzata. Ciò è permesso
-    raggruppando ed organizzando tutti gli strumenti e le regole adoperati.
+    raggruppando ed organizzando tutte le regole e gli strumenti adoperati.
  \subsection{Versionamento}
    \subsubsection{Codice di versione}
-   La storia di una risorsa deve sempre poter essere ricostrubibile in quanto nel suo arco di vita essa subisce
+   La storia di una risorsa deve sempre poter essere ricostruibile in quanto nel suo arco di vita essa subisce
    svariate modifiche. A tal scopo è fondamentale l'introduzione di un sistema di identificazione della
    versione:
    \begin{center}
@@ -221,8 +222,7 @@ Per ogni periodo pianificato e per cui si è fatto un preventivo si vuole indica
  \subsection{Sistemi software utilizzati}
  Per la gestione delle differenti versioni è stato deciso di utilizzare il sistema
  di versionamento distribuito Git; utilizzando il servizio GitHub per gestire la repository.\\
- Per la suddivisione e la gestione dei lavori da svolgere il nostro gruppo ha deciso di appoggiarsi
- al servizio web Trello.\\
+ Per la suddivisione e la gestione dei lavori da svolgere il nostro gruppo utilizza il sistema di Issue e Pull Request di GitHub.\\
 
  \subsection{Struttura repository}
   \subsubsection{Repository utilizzata}


### PR DESCRIPTION
In dettaglio:
- #55 Rimosso Trello dai processi di supporto (ricordo che Trello è ancora attivo per processi organizzativi);
- #84 Aggiunti termini sul glossario in Google Docs;
- #85 Non si parla di struttura del documento (non centra l'intestazione, titolo, registro modifiche, indice, etc...) ma di struttura delle pagine. Le nostre pagine non hanno una struttura complessa, quindi ho rimosso questo paragrafo;
- #86 Aggiunta breve descrizione e utilizzo del glossario;
- #88 Rimosso todo, la documentazione sembra sufficiente;
- **[not_done]** #89 Non completato. Fortemente legato al *PdQ*, forse è meglio se ne occupi qualcuno che ci ha lavorato di più e conosce meglio il documento;
-  #90 Chiuso senza modifiche. Prima di inserire una lista infinita di di link a D3, vediamo cosa ci consiglia il proponente e quali fonti sono effettivamente risultate utili. Rimosso "TODO" generico, il documento verrà aggiornato in corso d'opera con le risorse necessarie;
- Fix vari:
  - Alcuni errori di grammatica, sintassi;
  - 2.2.3 Analisi dei Requisiti: reinserita la "tipologia" per i requisiti.