### PR TITLE
Corretto bug nella lista di distribuzione

### DIFF
--- a/src/documenti/esterni/AdR/contenuti/listaDistribuzione.tex
+++ b/src/documenti/esterni/AdR/contenuti/listaDistribuzione.tex
@@ -1,9 +1,10 @@
-\centering
-\begin{tabular}{r|L{4cm}}
-		\multicolumn{2}{c}{\textbf{Informazioni sul documento} } \\
-		\hline
-		\textbf{Versione}			& V \\
-		\textbf{Uso}		& Esterno \\
-		\textbf{Data approvazione} 			& xx/03/2022 \\
-		\textbf{Distribuzione} 	&	Prof.\textit{Vardanega Tullio} \newline Prof.\textit{Cardin Riccardo} \newline Gruppo \textit{MERL} \\
-\end{tabular}
+\begin{center}
+	\begin{tabular}{r|L{4cm}}
+			\multicolumn{2}{c}{\textbf{Informazioni sul documento} } \\
+			\hline
+			\textbf{Versione}			& V \\
+			\textbf{Uso}		& Esterno \\
+			\textbf{Data approvazione} 			& xx/03/2022 \\
+			\textbf{Distribuzione} 	&	Prof.\textit{Vardanega Tullio} \newline Prof.\textit{Cardin Riccardo} \newline Gruppo \textit{MERL} \\
+	\end{tabular}
+\end{center}

--- a/src/documenti/esterni/PdP/contenuti/listaDistribuzione.tex
+++ b/src/documenti/esterni/PdP/contenuti/listaDistribuzione.tex
@@ -1,9 +1,10 @@
-\centering
-\begin{tabular}{r|L{4cm}}
-		\multicolumn{2}{c}{\textbf{Informazioni sul documento} } \\
-		\hline
-		\textbf{Versione}			& V \\
-		\textbf{Uso}		& Esterno \\
-		\textbf{Data approvazione} 			& xx/03/2022 \\
-		\textbf{Distribuzione} 	&	Prof.\textit{Vardanega Tullio} \newline Prof.\textit{Cardin Riccardo} \newline Gruppo \textit{MERL} \\
-\end{tabular}
+\begin{center}
+	\begin{tabular}{r|L{4cm}}
+			\multicolumn{2}{c}{\textbf{Informazioni sul documento} } \\
+			\hline
+			\textbf{Versione}			& V \\
+			\textbf{Uso}		& Esterno \\
+			\textbf{Data approvazione} 			& xx/03/2022 \\
+			\textbf{Distribuzione} 	&	Prof.\textit{Vardanega Tullio} \newline Prof.\textit{Cardin Riccardo} \newline Gruppo \textit{MERL} \\
+	\end{tabular}
+\end{center}

--- a/src/documenti/esterni/PdQ/contenuti/listaDistribuzione.tex
+++ b/src/documenti/esterni/PdQ/contenuti/listaDistribuzione.tex
@@ -1,9 +1,11 @@
-\centering
-\begin{tabular}{r|L{4cm}}
+\begin{center}
+	\begin{tabular}{r|L{4cm}}
 		\multicolumn{2}{c}{\textbf{Informazioni sul documento} } \\
 		\hline
 		\textbf{Versione}			& V \\
 		\textbf{Uso}		& Esterno \\
 		\textbf{Data approvazione} 			& xx/03/2022 \\
 		\textbf{Distribuzione} 	&	Prof.\textit{Vardanega Tullio} \newline Prof.\textit{Cardin Riccardo} \newline Gruppo \textit{MERL} \\
-\end{tabular}
+	\end{tabular}
+\end{center}
+	

--- a/src/documenti/interni/NdP/contenuti/listaDistribuzione.tex
+++ b/src/documenti/interni/NdP/contenuti/listaDistribuzione.tex
@@ -1,9 +1,11 @@
-\centering
-\begin{tabular}{r|L{4cm}}
+\begin{center}
+	\begin{tabular}{r|L{4cm}}
 		\multicolumn{2}{c}{\textbf{Informazioni sul documento} } \\
 		\hline
 		\textbf{Versione}			& V \\
 		\textbf{Uso}		& Interno \\
 		\textbf{Data approvazione} 			& xx/03/2022 \\
 		\textbf{Distribuzione} 	&	Prof.\textit{Vardanega Tullio} \newline Prof.\textit{Cardin Riccardo} \newline Gruppo \textit{MERL} \\
-\end{tabular}
+	\end{tabular}
+\end{center}
+	


### PR DESCRIPTION
Bug nella lista di distribuzione che causava tutti i titoli di capitoli e sezioni ad essere allineati in modo strano